### PR TITLE
Update to elm 0.18.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,7 @@
         "Debounce"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.5 <= v < 5.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.17.1 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/examples/Button.elm
+++ b/examples/Button.elm
@@ -1,7 +1,6 @@
 module Main exposing (..)
 
 import Html exposing (..)
-import Html.App as App
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
 import Debounce
@@ -18,9 +17,8 @@ type Msg
     | Deb (Debounce.Msg Msg)
 
 
-main : Program Never
 main =
-    App.program
+    Html.program
         { init = init
         , view = view
         , update = update

--- a/examples/Input.elm
+++ b/examples/Input.elm
@@ -1,7 +1,6 @@
 module Main exposing (..)
 
 import Html exposing (..)
-import Html.App as App
 import Html.Attributes exposing (..)
 import Html.Events exposing (onInput)
 import Debounce
@@ -18,9 +17,8 @@ type Msg
     | Deb (Debounce.Msg Msg)
 
 
-main : Program Never
 main =
-    App.program
+    Html.program
         { init = init
         , view = view
         , update = update

--- a/examples/ManagedInput.elm
+++ b/examples/ManagedInput.elm
@@ -1,7 +1,6 @@
 module Main exposing (..)
 
 import Html exposing (..)
-import Html.App as App
 import Html.Attributes exposing (..)
 import Html.Events exposing (onInput)
 import Debounce
@@ -20,9 +19,8 @@ type Msg
     | Deb (Debounce.Msg Msg)
 
 
-main : Program Never
 main =
-    App.program
+    Html.program
         { init = init
         , view = view
         , update = update

--- a/examples/ManyButtons.elm
+++ b/examples/ManyButtons.elm
@@ -1,7 +1,6 @@
 module Main exposing (..)
 
 import Html exposing (..)
-import Html.App as App
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
 import Debounce
@@ -20,9 +19,8 @@ type Msg
     | Deb (Debounce.Msg Msg)
 
 
-main : Program Never
 main =
-    App.program
+    Html.program
         { init = init
         , view = view
         , update = update

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -9,8 +9,8 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.5 <= v < 5.0.0",
-        "elm-lang/html": "1.1.0 <= v < 2.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.1 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -1,0 +1,24 @@
+module Helpers
+    exposing
+        ( deferredCmd
+        , deferredTask
+        )
+
+import Time exposing (Time)
+import Task exposing (Task)
+import Process
+
+
+deferredCmd : Time -> a -> Cmd a
+deferredCmd delay a =
+    Task.perform (always a) (Process.sleep delay)
+
+
+deferredTask : Time -> a -> Task Never a
+deferredTask delay a =
+    sleepSafe delay |> Task.andThen (always <| Task.succeed a)
+
+
+sleepSafe : Time -> Task Never ()
+sleepSafe =
+    Process.sleep >> (Task.mapError never)


### PR DESCRIPTION
Hi,

I was looking for debouncing and throttling packages in elm and stumbled upon your package and few others.
While I really liked the multitude of features of [jinjor/elm-debounce][jinjor] package (that deal with debounce, throttle and advanced manual control of debounced events), I loved the refined and efficient api of your package (and the doc storytelling ^^). It is very easy to extend one existing code and debounce already defined messages and update by just adding a few stuff.

So, since it is not up to elm 0.18 yet, I figured I could help updating it.
Could you tell me what you think ?

PS: Sorry if this feel a bit intrusive, this is really not my intent.

[jinjor]: http://package.elm-lang.org/packages/jinjor/elm-debounce/latest